### PR TITLE
Refined regex to match .js and /js with query strings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ function findJsLinks(folderPath: string, remove: boolean = false): void {
       findJsLinks(filePath, remove);
     } else if (fileStat.isFile() && path.extname(filePath) === ".js") {
       let fileContent = fs.readFileSync(filePath, "utf-8");
-      const links = fileContent.match(/https?:\/\/(?!.*redux)[^\s"]+\.js/g);
+      const links = fileContent.match(/https?:\/\/[^\s"']+(?:\.js|\/js)(?!.*redux)(\?[^#"'<>]*)?/g);
       if (links) {
         console.log(`JS link(s) found in ${filePath}:`);
         console.log(links);


### PR DESCRIPTION
Google was rejecting the CE because a tagmanager link added by firebase

<img width="437" alt="image" src="https://github.com/user-attachments/assets/5c83d15b-4b69-4ea6-a748-3ffd59e352a4">

I improved the regex also to remove these links /js links

before
<img width="566" alt="image" src="https://github.com/user-attachments/assets/6946ac5b-daa5-44bd-b3b4-55ae25d62848">

after (it grabbed a few more links running  on the same zip)
<img width="606" alt="image" src="https://github.com/user-attachments/assets/1b665867-4701-47e4-bdd2-69232ffa49f9">




